### PR TITLE
gsub_response() shouldn't fail on empty response bodies

### DIFF
--- a/R/redact.R
+++ b/R/redact.R
@@ -47,7 +47,7 @@ header_apply <- function(response, headers, FUN, ...) {
 within_body_text <- function(response, FUN) {
   # This could be applied to a httr2_request object;
   # only do work on a httr2_response
-  if (inherits(response, "httr2_response")) {
+  if (inherits(response, "httr2_response") && length(response$body)) {
     old <- resp_body_string(response)
     new <- FUN(old)
     response$body <- charToRaw(new)

--- a/tests/testthat/test-redact.R
+++ b/tests/testthat/test-redact.R
@@ -170,6 +170,18 @@ with_mock_api({
   })
 })
 
+test_that("gsub_response handles empty response bodies (#20)", {
+  with_redactor(
+    function(resp) gsub_response(resp, "status", "code"),
+    capture_requests({
+      # Prior to the fix, the redactor errored here on retrieving an empty body
+      r <- request(httpbin$url("/status/204")) %>% req_perform()
+    })
+  )
+  # Nothing here
+  expect_length(r$body, 0)
+})
+
 test_that("chain_redactors", {
   f1 <- function(x) x * 4
   f2 <- ~ sum(c(., 3))


### PR DESCRIPTION
Closes #20 