### PR TITLE
Check for body in the reponse before to read it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # httptest2 1.0.0.9000
 
 * `request` is now removed when saving `httr2_response` objects. In earlier versions of `httr2`, requests were not included in responses, but in httr2 1.0.0, [they were added](https://github.com/r-lib/httr2/pull/359) in order to improve error messages. *If you recorded any responses with httr2 >= 1.0 and httptest2 prior to this version, you may have leaked auth secrets: this would happen if your requests included auth information (as in an `Authentication` header), and the response was saved in a .R file, not simplified to .json or other response-body-only formats. Please inspect your recorded responses and invalidate any tokens that were exposed.*
+* `save_response` now works with `simplify = TRUE` and empty body responses (#37, @jmaspons)
 
 # httptest2 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # httptest2 1.0.0.9000
 
 * `request` is now removed when saving `httr2_response` objects. In earlier versions of `httr2`, requests were not included in responses, but in httr2 1.0.0, [they were added](https://github.com/r-lib/httr2/pull/359) in order to improve error messages. *If you recorded any responses with httr2 >= 1.0 and httptest2 prior to this version, you may have leaked auth secrets: this would happen if your requests included auth information (as in an `Authentication` header), and the response was saved in a .R file, not simplified to .json or other response-body-only formats. Please inspect your recorded responses and invalidate any tokens that were exposed.*
-* `save_response` now works with `simplify = TRUE` and empty body responses (#37, @jmaspons)
+* `save_response()` now works with `simplify = TRUE` when the response body is empty (#37, @jmaspons)
 
 # httptest2 1.0.0
 

--- a/R/capture-requests.R
+++ b/R/capture-requests.R
@@ -126,10 +126,14 @@ save_response <- function(response, file, simplify = TRUE) {
   ct <- resp_content_type(response)
   status <- resp_status(response)
   if (simplify && status == 200 && ct %in% names(CONTENT_TYPE_TO_EXT)) {
-    cont <- resp_body_string(response)
-    if (ct == "application/json") {
-      # Prettify
-      cont <- prettify(cont)
+    if (length(response$body)) {
+      cont <- resp_body_string(response)
+      if (ct == "application/json") {
+        # Prettify
+        cont <- prettify(cont)
+      }
+    } else {
+      cont <- character()
     }
     dst_file <- paste(dst_file, CONTENT_TYPE_TO_EXT[[ct]], sep = ".")
     cat_wb(cont, file = dst_file)

--- a/tests/testthat/test-capture-requests.R
+++ b/tests/testthat/test-capture-requests.R
@@ -30,6 +30,7 @@ test_that("We can record a series of requests (a few ways)", {
     r7 <<- request(httpbin$url("/image/webp")) %>%
       req_perform(path = webp_file)
     r8 <<- request(httpbin$url("/status/202")) %>% req_perform()
+    r9 <<- request(httpbin$url("/status/200")) %>% req_perform()
     stop_capturing()
   })
 
@@ -42,6 +43,7 @@ test_that("We can record a series of requests (a few ways)", {
     "httpbin.org/image/webp.R-FILE", # The `write_disk` location
     "httpbin.org/put-PUT.json", # Not a GET, but returns 200
     "httpbin.org/response-headers-ac4928.json",
+    "httpbin.org/status/200.txt", # 200 response, so .txt
     "httpbin.org/status/202.R", # Not 200 response, so .R
     "httpbin.org/status/418.R" # Not 200 response, so .R
   )
@@ -91,6 +93,7 @@ test_that("We can then load the mocks it stores", {
       m7 <- request(httpbin$url("/image/webp")) %>%
         req_perform(path = mock_webp_file)
       m8 <- request(httpbin$url("/status/202")) %>% req_perform()
+      m9 <- request(httpbin$url("/status/200")) %>% req_perform()
     })
   })
   expect_identical(resp_body_json(m1), resp_body_json(r1))
@@ -108,6 +111,9 @@ test_that("We can then load the mocks it stores", {
   expect_identical(resp_body_json(m6), content_r6)
   expect_identical(resp_body_raw(m7), content_r7)
   expect_equal(resp_status(m8), 202)
+  expect_equal(resp_status(m9), 200)
+  expect_equal(resp_content_type(m9), "text/plain")
+  expect_false(resp_has_body(m9))
 })
 
 test_that("write_disk mocks can be reloaded even if the mock directory moves", {

--- a/tests/testthat/test-capture-requests.R
+++ b/tests/testthat/test-capture-requests.R
@@ -43,7 +43,7 @@ test_that("We can record a series of requests (a few ways)", {
     "httpbin.org/image/webp.R-FILE", # The `write_disk` location
     "httpbin.org/put-PUT.json", # Not a GET, but returns 200
     "httpbin.org/response-headers-ac4928.json",
-    "httpbin.org/status/200.txt", # 200 response, so .txt
+    "httpbin.org/status/200.txt", # empty 200 response "text/plain", so .txt
     "httpbin.org/status/202.R", # Not 200 response, so .R
     "httpbin.org/status/418.R" # Not 200 response, so .R
   )


### PR DESCRIPTION
If the response has no body, write and empty file
FIX #35