### PR TITLE
fix: remove request from saved responses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: Testing and documenting code that communicates with remote servers
     test fixtures. The ability to save responses and load them offline also
     enables writing vignettes and other dynamic documents that can be
     distributed without access to a live server.
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R: c(
         person("Neal", "Richardson", role=c("aut", "cre"), email="neal.p.richardson@gmail.com", comment=c(ORCID="0009-0002-7992-3520")),
         person("Jonathan", "Keane", role="ctb", email="jkeane@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# httptest2 1.0.0.9000
+
+* `request` is now removed when saving `httr2_response` objects. In earlier versions of `httr2`, requests were not included in responses, but in httr2 1.0.0, [they were added](https://github.com/r-lib/httr2/pull/359) in order to improve error messages. *If you recorded any responses with httr2 >= 1.0 and httptest2 prior to this version, you may have leaked auth secrets: this would happen if your requests included auth information (as in an `Authentication` header), and the response was saved in a .R file, not simplified to .json or other response-body-only formats. Please inspect your recorded responses and invalidate any tokens that were exposed.*
+
 # httptest2 1.0.0
 
 * `capture_requests()` can be used without loading `library(httptest2)` (#22, @kforner)

--- a/R/capture-requests.R
+++ b/R/capture-requests.R
@@ -166,6 +166,7 @@ save_response <- function(response, file, simplify = TRUE) {
     }
     # Needed for httr2 1.0.0
     response$cache <- quote(new.env(parent = emptyenv()))
+    response$request <- NULL
 
     f <- file(dst_file, "wb", encoding = "UTF-8")
     on.exit(close(f))

--- a/tests/testthat/test-capture-requests.R
+++ b/tests/testthat/test-capture-requests.R
@@ -53,6 +53,7 @@ test_that("We can record a series of requests (a few ways)", {
   teapot <- source(file.path(d, httpbin_mock_url, "status", "418.R"))$value
   expect_s3_class(teapot, "httr2_response")
   expect_identical(resp_status(teapot), 418L)
+  expect_false("request" %in% names(teapot))
   # Make sure that our .html file has HTML
   expect_true(any(grepl(
     "</body>",


### PR DESCRIPTION
NEWS summary:

> `request` is now removed when saving `httr2_response` objects. In earlier versions of `httr2`, requests were not included in responses, but in httr2 1.0.0, [they were added](https://github.com/r-lib/httr2/pull/359) in order to improve error messages. *If you recorded any responses with httr2 >= 1.0 and httptest2 prior to this version, you may have leaked auth secrets: this would happen if your requests included auth information (as in an `Authentication` header), and the response was saved in a .R file, not simplified to .json or other response-body-only formats. Please inspect your recorded responses and invalidate any tokens that were exposed.*

cc @jmaspons