### PR TITLE
Fix invalid regular expression in "Set Redactor" guide

### DIFF
--- a/R/redactor.R
+++ b/R/redactor.R
@@ -30,7 +30,7 @@
 #' @seealso For further details on how to redact responses, see `vignette("redacting", package = "httptest2")`.
 #' @examples
 #' # Shorten UUIDs in response body/URLs to their first 6 digits:
-#' set_redactor(function(resp) gsub_response(resp, "([0-9a-f]{6}[0-9a-f]{26}", "\\1"))
+#' set_redactor(function(resp) gsub_response(resp, "([0-9a-f]{6})[0-9a-f]{26}", "\\1"))
 #' # Restore the default
 #' set_redactor(redact_cookies)
 set_redactor <- function(FUN) {

--- a/man/set_redactor.Rd
+++ b/man/set_redactor.Rd
@@ -42,7 +42,7 @@ vignettes), the function will be used automatically.
 }
 \examples{
 # Shorten UUIDs in response body/URLs to their first 6 digits:
-set_redactor(function(resp) gsub_response(resp, "([0-9a-f]{6}[0-9a-f]{26}", "\\\\1"))
+set_redactor(function(resp) gsub_response(resp, "([0-9a-f]{6})[0-9a-f]{26}", "\\\\1"))
 # Restore the default
 set_redactor(redact_cookies)
 }


### PR DESCRIPTION
I noticed that  the ) are missing in the regex expression, and results in a error once executed.