### PR TITLE
NEWS, refactor, prep for release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/devtools-test.yaml
+++ b/.github/workflows/devtools-test.yaml
@@ -19,7 +19,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # httptest2 1.1.0.9000
 
 * `build_mock_url()` now works with multipart body request containing character strings or raw data (#40, @jmaspons)
+* Compatibility with upcoming `httr2` release (#51, @hadley)
 
 # httptest2 1.1.0
 


### PR DESCRIPTION
`get_string_request_body()` was a little too clever, which made it hard to reason about in the previous PR. This PR tries to clarify its intent.