### PR TITLE
Add request to resp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: Testing and documenting code that communicates with remote servers
     test fixtures. The ability to save responses and load them offline also
     enables writing vignettes and other dynamic documents that can be
     distributed without access to a live server.
-Version: 1.2.2
+Version: 1.2.2.9000
 Authors@R: c(
         person("Neal", "Richardson", role=c("aut", "cre"), email="neal.p.richardson@gmail.com", comment=c(ORCID="0009-0002-7992-3520")),
         person("Jonathan", "Keane", role="ctb", email="jkeane@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # httptest2 (development version)
 
+* Reloaded mocked response objects now include the request that caused them to be loaded as `$request` (#65, @jonthegeek)
+
 # httptest2 1.2.2
 
 * Compatibility with `testthat` 3.3.0 (#60, @hadley)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# httptest2 (development version)
+
 # httptest2 1.2.2
 
 * Compatibility with `testthat` 3.3.0 (#60, @hadley)

--- a/R/mock-api.R
+++ b/R/mock-api.R
@@ -116,9 +116,9 @@ load_response <- function(file, req) {
   ext <- tail(unlist(strsplit(file, ".", fixed = TRUE)), 1)
   if (ext == "R") {
     # It's a full "response". Source it, and if it is from httr, adapt it
-    adapt_httr_response(source(file)$value)
+    resp <- adapt_httr_response(source(file)$value)
   } else if (ext %in% names(EXT_TO_CONTENT_TYPE)) {
-    response(
+    resp <- response(
       url = req$url,
       method = get_request_method(req),
       headers = list(`Content-Type` = EXT_TO_CONTENT_TYPE[[ext]]),
@@ -126,7 +126,7 @@ load_response <- function(file, req) {
       body = readBin(file, "raw", n = file.size(file))
     )
   } else if (ext == "204") {
-    response(
+    resp <- response(
       url = req$url,
       method = get_request_method(req),
       status_code = 204L
@@ -134,6 +134,8 @@ load_response <- function(file, req) {
   } else {
     stop("Unsupported mock file extension: ", ext, call. = FALSE)
   }
+  resp$request <- req
+  resp
 }
 
 adapt_httr_response <- function(resp) {

--- a/tests/testthat/test-mock-api.R
+++ b/tests/testthat/test-mock-api.R
@@ -219,6 +219,19 @@ with_mock_api({
       fixed = FALSE
     )
   })
+  test_that("Mocked responses include their request (#65)", {
+    req <- request("https://test.api/")
+    req$policies$example <- "example policy"
+    a <- req %>% req_perform()
+    expect_identical(
+      httr2::resp_request(a),
+      req
+    )
+    expect_identical(
+      httr2::resp_request(a)$policies$example,
+      "example policy"
+    )
+  })
 })
 
 test_that("build_mock_url file path construction with character URL", {


### PR DESCRIPTION
Add req to response objects as `$request`.

Fixes #65